### PR TITLE
Fixed gradle build scripts on Windows

### DIFF
--- a/lib/gradle.js
+++ b/lib/gradle.js
@@ -32,8 +32,7 @@ const tasks = (() => {
 /*
 task bundleLiquidCoreCode(type: Exec) {
   workingDir rootProject.projectDir
-  executable '/usr/bin/env'
-  args = ['node', 'node_modules/liquidcore/lib/cli.js', 'bundle', '--platform=android']
+  commandLine 'node', 'node_modules/liquidcore/lib/cli.js', 'bundle', '--platform=android'
 }
 project.afterEvaluate {
     preBuild.dependsOn bundleLiquidCoreCode
@@ -86,6 +85,10 @@ const gradle = async (override) => {
         let pth = android.dev && path.resolve(resolved, android.dev)
         module.inc = android.include && path.relative(path.resolve('.'),
           path.resolve(resolved, android.include))
+        // on Windows `path.resolve` returns a path with non-escaped backslashes which does not
+        // represent a valid string in Gradle; so, make the path processable by all OSes using
+        // forward slashes instead
+        module.inc = module.inc.split("\\").join("/")
         if (aar) {
           try {
             fs.realpathSync(aar)


### PR DESCRIPTION
Tested on Windows 10 and Kubuntu. Can't check on Mac OS as don't have it.
There were two options for slashes: either escape them ("\\" > "\\\\") or replace them with forward slashes ("\\" > "/"). Chose the latter one as this style is a bit more common across OSes and is supported by Windows